### PR TITLE
Improving argspec names

### DIFF
--- a/openshift/ansiblegen/docstrings.py
+++ b/openshift/ansiblegen/docstrings.py
@@ -83,6 +83,8 @@ class DocStrings(object):
                 doc_string['options'][pname]['default'] = pdict['default']
             if pdict.get('choices'):
                 doc_string['options'][pname]['choices'] = pdict['choices']
+            if pdict.get('aliases'):
+                doc_string['options'][pname]['aliases'] = pdict['aliases']
 
         for param_name in sorted(self.helper.argspec.keys()):
             param_dict = self.helper.argspec[param_name]


### PR DESCRIPTION
Makes long argspec names, which stem from recursion into the model, more meaningful by deriving the name from the recursed property class, rather than the property name. This changes yields the following examples from the deployment model:

- `deployment_spec_deployment_strategy_type`
- `deployment_spec_label_selector_match_labels`
- `deployment_spec_pod_template_spec_pod_spec_active_deadline_seconds`

In addition to hopefully making the longer names be more friendly, this also adds `alisases` to the long names. Take the above examples, we get the following aliases in the respective order:

- `strategy_type`
- `label_selector_match_labels`
- `pod_active_deadline_seconds`

Also, adds ARGS_ATTRIBUTES_BLACKLIST as a list of attributes included in the argspec property that `module_utils/k8s_common.py` should remove when building the argument_spec. And yes, that's been updated to build an argument_spec from the data returned by the argspec property in hopes of helping Ansible contributors understand how the argumentspec gets built, and potentially impact it, if needed. 


