### PR TITLE
Update state parameter. Add force parameter.

### DIFF
--- a/openshift/helper/ansible.py
+++ b/openshift/helper/ansible.py
@@ -33,13 +33,23 @@ class AnsibleMixin(object):
         argument_spec = {
             'state': {
                 'default': 'present',
-                'choices': ['present', 'absent', 'replaced'],
+                'choices': ['present', 'absent'],
                 'description': [
-                    "Determines if the object should be created, patched, deleted or replaced. When set to "
-                    "C(present), the object will be created, if it does not exist, or patched, if requested "
-                    "parameters differ from existing object attributes. If set to C(absent), an existing "
-                    "object will be deleted, and if set to C(replaced), an existing object will be completely "
-                    "replaced with a new object created from the supplied parameters."
+                    "Determines if an object should be created, patched, or deleted. When set to "
+                    "C(present), the object will be created, if it does not exist, or patched, if parameter "
+                    "values differ from the existing object's attributes, and deleted, if set to C(absent). A patch "
+                    "operation results in merging lists and updating dictionaries, with lists being merged into a "
+                    "unique set of values. If a list contains a dictionary with a I(name) or I(type) attribute, "
+                    "a strategic merge is performed, where individual elements with a matching I(name_) or I(type) are "
+                    "merged. To force the replacement of lists, set the I(force) option to C(True)."
+                ]
+            },
+            'force': {
+                'type': 'bool',
+                'default': False,
+                'description': [
+                    "If set to C(True), and I(state) is C(present), an existing object will updated, and lists will "
+                    "be replaced, rather than merged."
                 ]
             },
             'kubeconfig': {


### PR DESCRIPTION
Per comments form bcoca:

- clarifies difference between `patch` and `replace`
- removes `replaced` state
- adds a `force` option. Combine with state `present` to cause a `replace`