### PR TITLE
fix ruamel.yaml on 0.14.X for now

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ dictdiffer
 jinja2
 kubernetes ~= 1.0.0
 python-string-utils
-ruamel.yaml
+ruamel.yaml<0.15
 six


### PR DESCRIPTION
Thank you for using ruamel.yaml. 

There will be API changes in the 0.15+ versions, that might lead to warnings that 
your users could see. 
Therefore please release a version of your package with this change, so that it will not 
automatically take the latest ruamel.yaml release.
