### PR TITLE
Don't require a config file for k8s/openshift

### DIFF
--- a/openshift/helper/kubernetes.py
+++ b/openshift/helper/kubernetes.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import
 from kubernetes import config
 from kubernetes.client import models as k8s_models
 from kubernetes.client import apis as k8s_apis
+from kubernetes.client import ApiClient, ConfigurationObject
 
 from . import VERSION_RX
 from .base import BaseObjectHelper
@@ -13,6 +14,8 @@ from .exceptions import KubernetesException
 class KubernetesObjectHelper(BaseObjectHelper):
     @staticmethod
     def client_from_config(config_file, context):
+        if not config_file:
+            return ApiClient(config=ConfigurationObject())
         return config.new_client_from_config(config_file, context)
 
     @classmethod

--- a/openshift/helper/openshift.py
+++ b/openshift/helper/openshift.py
@@ -12,6 +12,7 @@ from . import VERSION_RX
 from .. import config
 from ..client import models as openshift_models
 from ..client import apis as openshift_apis
+from ..client import ApiClient, ConfigurationObject
 from .base import BaseObjectHelper
 from .exceptions import OpenShiftException
 
@@ -19,6 +20,8 @@ from .exceptions import OpenShiftException
 class OpenShiftObjectHelper(BaseObjectHelper):
     @staticmethod
     def client_from_config(config_file, context):
+        if not config_file:
+            return ApiClient(config=ConfigurationObject())
         return config.new_client_from_config(config_file, context)
 
     @classmethod


### PR DESCRIPTION
It's possible to interact with the Kubernetes/OpenShift API without auth
or even without a configuration file. This patch allows for creating an
ApiClient instance without loading it from a configuration file if it is
not set.

r? @chouseknecht 