### PR TITLE
Allow preprocess_script to be imported

### DIFF
--- a/scripts/preprocess_spec.py
+++ b/scripts/preprocess_spec.py
@@ -195,5 +195,5 @@ def main():
                       separators=(',', ': '), ensure_ascii=True)
     return 0
 
-
-sys.exit(main())
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
I'm doing some automated analysis of the OpenAPI spec to introspect properties of the Kubernetes and Openshift clients, and it's much easier if I can import preprocess_spec.py to call the relevant function directly.