### PR TITLE
Fix module Python interpreter

### DIFF
--- a/openshift/ansiblegen/templates/k8s_module.j2
+++ b/openshift/ansiblegen/templates/k8s_module.j2
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 from ansible.module_utils.k8s_common import KubernetesAnsibleModule, KubernetesAnsibleException
 

--- a/openshift/ansiblegen/templates/openshift_module.j2
+++ b/openshift/ansiblegen/templates/openshift_module.j2
@@ -1,4 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
 
 from ansible.module_utils.openshift_common import OpenShiftAnsibleModule, OpenShiftAnsibleException
 


### PR DESCRIPTION
In Ansible module templates:

- Set interpreter to `#!/usr/bin/python`, matching what Ansible expects
- Add encoding header