### PR TITLE
Fix missing "tags" key error when running preprocess_spec on a live OpenShift spec

### DIFF
--- a/scripts/from_gen/preprocess_spec.py
+++ b/scripts/from_gen/preprocess_spec.py
@@ -96,10 +96,12 @@ def remove_watch_operations(op, parent, operation_ids):
 
 def strip_tags_from_operation_id(operation, _):
     operation_id = operation['operationId']
-    for t in operation['tags']:
-        operation_id = operation_id.replace(_to_camel_case(t), '')
-    operation['operationId'] = operation_id
-
+    try:
+        for t in operation['tags']:
+            operation_id = operation_id.replace(_to_camel_case(t), '')
+        operation['operationId'] = operation_id
+    except KeyError:
+        pass
 
 def add_custom_objects_spec(spec):
     with open(CUSTOM_OBJECTS_SPEC_PATH, 'r') as custom_objects_spec_file:


### PR DESCRIPTION
I'm pulling the OpenAPI spec from running OpenShift clusters using the /swagger.json endpoint and introspecting information about the Python client.  To make sure the names match, I'm running preprocess_spec.py on it before I examine it.  When I do, I get a KeyError when the operation doesn't have the 'tags' key, for instance:

```
operation = {'description': 'create a Template', 'consumes': ['*/*'], 'produces': ['application/json', 'application/yaml', 'application/vnd.kubernetes.protobuf'], 'schemes': ['https'], 'operationId': 'createNamespacedProcessedTemplateV1', 'parameters': [{'name': 'body', 'in': 'body', 'required': True, 'schema': {'$ref': '#/definitions/com.github.openshift.origin.pkg.template.apis.template.v1.Template'}}], 'responses': {'200': {'description': 'OK', 'schema': {'$ref': '#/definitions/com.github.openshift.origin.pkg.template.apis.template.v1.Template'}}, '401': {'description': 'Unauthorized'}}}
```

This pull request simply ignores operations without the tags key.  I don't know why you don't see this when running this script to generate the client or that this is the right fix.  If the issue is something else, I can amend my pull request.