### PR TITLE
Fix k8s_v1beta1_role_binding 404s

### DIFF
--- a/openshift/ansiblegen/examples/k8s_v1beta1_role_binding.yml
+++ b/openshift/ansiblegen/examples/k8s_v1beta1_role_binding.yml
@@ -1,6 +1,11 @@
 # v1beta1_role_binding.yml
 ---
 
+version_limits:
+  min: '3.7'
+  max: '3.7'
+  skip_latest: yes
+
 dependencies:
   - k8s_v1beta1_role:
       name: edit

--- a/openshift/ansiblegen/examples/k8s_v1beta1_role_binding.yml
+++ b/openshift/ansiblegen/examples/k8s_v1beta1_role_binding.yml
@@ -1,0 +1,12 @@
+# v1beta1_role_binding.yml
+---
+
+tasks:
+- create:
+    name: edit
+    namespace: test
+    subjects:
+    - kind: ServiceAccount
+      name: magico
+      namespace: test
+  name: Create role binding

--- a/openshift/ansiblegen/examples/k8s_v1beta1_role_binding.yml
+++ b/openshift/ansiblegen/examples/k8s_v1beta1_role_binding.yml
@@ -1,10 +1,17 @@
 # v1beta1_role_binding.yml
 ---
 
+dependencies:
+  - k8s_v1beta1_role:
+      name: edit
+      namespace: test
+
 tasks:
 - create:
     name: edit
     namespace: test
+    role_ref_kind: Role
+    role_ref_name: edit
     subjects:
     - kind: ServiceAccount
       name: magico

--- a/openshift/helper/base.py
+++ b/openshift/helper/base.py
@@ -414,7 +414,11 @@ class BaseObjectHelper(object):
         return result
 
     def candidate_apis(self):
-        return list(filter(lambda x: self.api_version in self.attribute_to_snake(x), self.available_apis()))
+        return [
+            api for api in self.available_apis()
+            if self.api_version in self.attribute_to_snake(api)
+            or not VERSION_RX.match(api)
+        ]
 
     def lookup_method(self, operation=None, namespace=None, method_name=None):
         """

--- a/openshift/helper/base.py
+++ b/openshift/helper/base.py
@@ -413,6 +413,9 @@ class BaseObjectHelper(object):
             }
         return result
 
+    def candidate_apis(self):
+        return list(filter(lambda x: self.api_version in self.attribute_to_snake(x), self.available_apis()))
+
     def lookup_method(self, operation=None, namespace=None, method_name=None):
         """
         Get the requested method (e.g. create, delete, patch, update) for
@@ -427,7 +430,7 @@ class BaseObjectHelper(object):
             method_name += self.kind.replace('_list', '') if self.kind.endswith('_list') else self.kind
 
         method = None
-        for api in self.available_apis():
+        for api in self.candidate_apis():
             api_class = self.api_class_from_name(api)
 
             method = getattr(api_class(self.api_client), method_name, None)


### PR DESCRIPTION
@karmab
closes #121 

Issue was caused because when choosing with API to hit it looked for a matching method name, and didn't filter it by API version. In this case, v1alpha1 and v1beta1 APIs for the same resource existed, and alpha1 matched first. 

I also updated the tests to include a role binding test, and updated the test runner so that you can specify dependencies to be created before running the main task.