### PR TITLE
Add custom_objects_spec.json to package data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,12 @@ setup(
     install_requires=extract_requirements('requirements.txt'),
     packages=find_packages(include='openshift.*'),
     include_package_data=True,
-    data_files=[('requirements.txt', ['requirements.txt'])],
+    data_files=[
+        ('requirements.txt', ['requirements.txt']),
+        ('custom_objects_spec.json',
+         ['scripts/from_gen/custom_objects_spec.json']
+        )
+    ],
     long_description='Python client for OpenShift http://openshift.redhat.com/',
     classifiers=[
         "Development Status :: %s" % DEVELOPMENT_STATUS,


### PR DESCRIPTION
This file is required for the use of the preprocess_spec.py script but is missing from the PyPi package.