### PR TITLE
Fixes a bug when running fix_serialization on Kubernetes ExternalName…

### DIFF
--- a/openshift/helper/base.py
+++ b/openshift/helper/base.py
@@ -175,7 +175,7 @@ class BaseObjectHelper(object):
         return method is not None
 
     def fix_serialization(self, obj):
-        if obj and obj.kind == "Service" and obj.spec.type != "ExternalName":
+        if obj and obj.kind == "Service" and obj.spec.ports:
             for port in obj.spec.ports:
                 try:
                     port.target_port = int(port.target_port)

--- a/openshift/helper/base.py
+++ b/openshift/helper/base.py
@@ -175,7 +175,7 @@ class BaseObjectHelper(object):
         return method is not None
 
     def fix_serialization(self, obj):
-        if obj and obj.kind == "Service":
+        if obj and obj.kind == "Service" and obj.spec.type != "ExternalName":
             for port in obj.spec.ports:
                 try:
                     port.target_port = int(port.target_port)


### PR DESCRIPTION
This bug popped up when specifically using the k8s_raw module with ansible.

When the `fix_serialization` function is with a service definition like below it runs into the following error message because no ports need to be specified
Example service definition:
```
---
apiVersion: v1
kind: Service
metadata:
  name: mysql-server
  namespace: default
spec:
  externalName: <some dns address>
  type: ExternalName
```

Error
```
Traceback (most recent call last):
  File \"/tmp/ansible_beh9U6/ansible_module_k8s_raw.py\", line 163, in <module>
    main()
  File \"/tmp/ansible_beh9U6/ansible_module_k8s_raw.py\", line 159, in main
    KubernetesRawModule().execute_module()
  File \"/tmp/ansible_beh9U6/ansible_modlib.zip/ansible/module_utils/k8s/raw.py\", line 145, in execute_module
  File \"/usr/lib/python2.7/site-packages/openshift/helper/base.py\", line 179, in fix_serialization
    for port in obj.spec.ports:
TypeError: 'NoneType' object is not iterable

```