### PR TITLE
Allow merge type specification in resource.patch

### DIFF
--- a/openshift/dynamic/client.py
+++ b/openshift/dynamic/client.py
@@ -185,10 +185,8 @@ class DynamicClient(object):
         if resource.namespaced:
             namespace = self.ensure_namespace(resource, namespace, body)
 
+        content_type = kwargs.pop('content_type', 'application/strategic-merge-patch+json')
         path = resource.path(name=name, namespace=namespace, **kwargs)
-
-        content_type = self.client.\
-            select_header_content_type(['application/json-patch+json', 'application/merge-patch+json', 'application/strategic-merge-patch+json'])
 
         return self.request('patch', path, body=body, content_type=content_type)
 


### PR DESCRIPTION
For Custom Resource Definitions, the strategic merge type will fail
with "strategic merge patch format is not supported".

Allow the override of merge type when patching so that all three
patch merge types are individually choosable - this means that
JSON Merge Patch operations can be chosen for certain operations