### PR TITLE
Update kube_config to support concurrent clusters

### DIFF
--- a/openshift/config/kube_config.py
+++ b/openshift/config/kube_config.py
@@ -6,7 +6,7 @@ def new_client_from_config(config_file=None, context=None):
     """Loads configuration the same as load_kube_config but returns an ApiClient
     to be used with any API object. This will allow the caller to concurrently
     talk with multiple clusters."""
-    client_config = Configuration()
+    client_config = type.__call__(Configuration)
     load_kube_config(config_file=config_file, context=context,
                      client_configuration=client_config)
     return ApiClient(configuration=client_config)


### PR DESCRIPTION
The kube_config module needs to use that client_config constructor to
properly support concurrent cluster configuration. This line is
imported from the kubernetes python client.