### PR TITLE
Provide 'append_hash' for ConfigMaps and Secrets

### DIFF
--- a/openshift/helper/hashes.py
+++ b/openshift/helper/hashes.py
@@ -1,0 +1,50 @@
+# Implement ConfigMapHash and SecretHash equivalents
+# Based on https://github.com/kubernetes/kubernetes/pull/49961
+
+import json
+import hashlib
+
+try:
+    import string
+    maketrans = string.maketrans
+except AttributeError:
+    maketrans = str.maketrans
+
+try:
+    from collections import OrderedDict
+except ImportError:
+    from orderreddict import OrderedDict
+
+
+def sorted_dict(unsorted_dict):
+    result = OrderedDict()
+    for (k, v) in sorted(unsorted_dict.items()):
+        if isinstance(v, dict):
+            v = sorted_dict(v)
+        result[k] = v
+    return result
+
+
+def generate_hash(resource):
+    # Get name from metadata
+    resource['name'] = resource.get('metadata', {}).get('name', '')
+    if resource['kind'] == 'ConfigMap':
+        marshalled = marshal(sorted_dict(resource), ['data', 'kind', 'name'])
+        del(resource['name'])
+        return encode(marshalled)
+    if resource['kind'] == 'Secret':
+        marshalled = marshal(sorted_dict(resource), ['data', 'kind', 'name', 'type'])
+        del(resource['name'])
+        return encode(marshalled)
+    raise NotImplementedError
+
+
+def marshal(data, keys):
+    ordered = OrderedDict()
+    for key in keys:
+        ordered[key] = data.get(key, "")
+    return json.dumps(ordered, separators=(',', ':')).encode('utf-8')
+
+
+def encode(resource):
+    return hashlib.sha256(resource).hexdigest()[:10].translate(maketrans("013ae", "ghkmt"))

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
-coverage
+coverage>=3.7.1
 docker ~= 2.1.0
 flake8
 pytest < 3.3

--- a/test/unit/test_hashes.py
+++ b/test/unit/test_hashes.py
@@ -1,0 +1,68 @@
+# Test ConfigMapHash and SecretHash equivalents
+# tests based on https://github.com/kubernetes/kubernetes/pull/49961
+
+from openshift.helper.hashes import generate_hash
+
+tests = [
+    dict(
+        resource = dict(
+            kind="ConfigMap",
+            metadata=dict(name="foo"),
+            data=dict()
+        ),
+        expected = "867km9574f",
+    ),
+    dict(
+        resource = dict(
+            kind="ConfigMap",
+            metadata=dict(name="foo"),
+            type="my-type",
+            data=dict()
+        ),
+        expected = "867km9574f",
+    ),
+    dict(
+        resource = dict(
+            kind="ConfigMap",
+            metadata=dict(name="foo"),
+            data=dict(
+                key1="value1",
+                key2="value2")
+        ),
+        expected = "gcb75dd9gb",
+    ),
+    dict(
+        resource = dict(
+            kind="Secret",
+            metadata=dict(name="foo"),
+            data=dict()
+        ),
+        expected = "949tdgdkgg",
+    ),
+    dict(
+        resource = dict(
+            kind="Secret",
+            metadata=dict(name="foo"),
+            type="my-type",
+            data=dict()
+        ),
+        expected = "dg474f9t76",
+    ),
+
+    dict(
+        resource = dict(
+            kind="Secret",
+            metadata=dict(name="foo"),
+            data=dict(
+                key1="dmFsdWUx",
+                key2="dmFsdWUy")
+        ),
+        expected = "tf72c228m4",
+    )
+
+]
+
+
+def test_hashes():
+    for test in tests:
+        assert(generate_hash(test['resource']) == test['expected'])

--- a/test/unit/test_marshal.py
+++ b/test/unit/test_marshal.py
@@ -1,0 +1,74 @@
+# Test ConfigMap and Secret marshalling
+# tests based on https://github.com/kubernetes/kubernetes/pull/49961
+
+from openshift.helper.hashes import marshal, sorted_dict
+
+tests = [
+    dict(
+        resource=dict(
+            kind="ConfigMap",
+            name="",
+            data=dict(),
+        ),
+        expected=b'{"data":{},"kind":"ConfigMap","name":""}'
+    ),
+    dict(
+        resource=dict(
+            kind="ConfigMap",
+            name="",
+            data=dict(
+                one=""
+            ),
+        ),
+        expected=b'{"data":{"one":""},"kind":"ConfigMap","name":""}'
+    ),
+    dict(
+        resource=dict(
+            kind="ConfigMap",
+            name="",
+            data=dict(
+                two="2",
+                one="",
+                three="3",
+            ),
+        ),
+        expected=b'{"data":{"one":"","three":"3","two":"2"},"kind":"ConfigMap","name":""}'
+    ),
+    dict(
+        resource=dict(
+            kind="Secret",
+            type="my-type",
+            name="",
+            data=dict(),
+        ),
+        expected=b'{"data":{},"kind":"Secret","name":"","type":"my-type"}'
+    ),
+    dict(
+        resource=dict(
+            kind="Secret",
+            type="my-type",
+            name="",
+            data=dict(
+                one=""
+            ),
+        ),
+        expected=b'{"data":{"one":""},"kind":"Secret","name":"","type":"my-type"}'
+    ),
+    dict(
+        resource=dict(
+            kind="Secret",
+            type="my-type",
+            name="",
+            data=dict(
+                two="Mg==",
+                one="",
+                three="Mw==",
+            ),
+        ),
+        expected=b'{"data":{"one":"","three":"Mw==","two":"Mg=="},"kind":"Secret","name":"","type":"my-type"}'
+    ),
+]
+
+def test_marshal():
+    for test in tests:
+        assert(marshal(sorted_dict(test['resource']), sorted(list(test['resource'].keys()))) == test['expected'])


### PR DESCRIPTION
kubectl --append-hash adds a hash value to the name of a configmap
or secret so that they can be used immutably.

Using the same algorithms here, consumers of the dynamic client
can ask for a hash to be appended to a configmap or secret name.

To generate the hash requires the data, so `get` and `delete`
have been backwardly compatibly updated to accept parameters to
generate the hash