### PR TITLE
Default the ssl ca cert to ssl's default ca

### DIFF
--- a/openshift/dynamic/client.py
+++ b/openshift/dynamic/client.py
@@ -55,8 +55,17 @@ class DynamicClient(object):
     def __init__(self, client):
         self.client = client
         self.configuration = client.configuration
+        self.set_default_ca_cert()
         self._load_server_info()
         self.__resources = ResourceContainer(self.parse_api_groups())
+
+    def set_default_ca_cert(self):
+        if self.configuration.ssl_ca_cert is None:
+            try:
+                import ssl
+                self.configuration.ssl_ca_cert = ssl.get_default_verify_paths().cafile
+            except Exception:
+                pass
 
     def _load_server_info(self):
         self.__version = {'kubernetes': load_json(self.request('get', '/version'))}


### PR DESCRIPTION
closes #198 

@dlabajo I think this might fix your issue, it looks like Python libraries don't really use the default system ca. Let me know if this fixes your issue. As a workaround you can also just specify the path to your system ca. 
