### PR TITLE
Allow less strict kubernetes version requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 dictdiffer
 jinja2
-kubernetes == 7.0.0
+kubernetes >= 7.0.0, < 8.0.0
 python-string-utils
 ruamel.yaml >= 0.15
 six


### PR DESCRIPTION
Newer versions of kubernetes client that incorporate bug fixes
independent of openshift client releases should be allowed

Pin to less than 8.0.0 to reduce risk of breaking changes