### PR TITLE
Do not decode response data in Python2

### DIFF
--- a/openshift/dynamic/client.py
+++ b/openshift/dynamic/client.py
@@ -4,6 +4,7 @@ import sys
 import copy
 import json
 from functools import partial
+from six import PY2
 
 import yaml
 from pprint import pformat
@@ -50,10 +51,14 @@ def serialize(resource, response):
     try:
         return ResourceInstance(resource, load_json(response))
     except ValueError:
-        return response.data.decode()
+        if PY2:
+            return response.data
+        return response.data.decode('utf8')
 
 def load_json(response):
-    return json.loads(response.data.decode())
+    if PY2:
+        return json.loads(response.data)
+    return json.loads(response.data.decode('utf8'))
 
 
 class DynamicClient(object):


### PR DESCRIPTION
response data is already str in Python2 so it doesn't need to be decoded.
Furthermore, as decode() uses ascii by default in PY2, it breaks in case of a non-ascii character the response.
Just mimic what kubernetes do in https://github.com/kubernetes-client/python/blob/master/kubernetes/client/rest.py#L216
Fix #224