### PR TITLE
ResourceContainer does not contain delete method

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ For List kind resources (ie, the resource name ends in `List`), the `delete` imp
 Rather than taking a name, they take a `*List` kind definition and call `delete` for each definition in the list.
 
 ```python
-v1_service_list = dyn_client.resources.delete(api_version='v1', kind='ServiceList')
+v1_service_list = dyn_client.resources.get(api_version='v1', kind='ServiceList')
 
 body = {
     'kind': 'ServiceList',


### PR DESCRIPTION
I was falling into:

```
Traceback (most recent call last):
  File "/home/morsik/Projects/venv/lib/python3.6/site-packages/apscheduler/executors/base.py", line 125, in run_job
    retval = job.func(*job.args, **job.kwargs)
  File "/home/morsik/Projects/venv/lib/python3.6/site-packages/nameguard-1.0-py3.6.egg/nameguard/nameguard.py", line 196, in job_delete_project
    v1_projects = ctx.client.resources.delete(
AttributeError: 'ResourceContainer' object has no attribute 'delete'
```

It looks like first example contains `.get()` which works, but this one I changed contains `.delete()` which does not exists in code there. Looks like using `.get()` works.