### PR TITLE
Add a message about kubernetes version not being supported

### DIFF
--- a/openshift/dynamic/client.py
+++ b/openshift/dynamic/client.py
@@ -335,6 +335,8 @@ class DynamicClient(object):
             kubernetes_validate.validate(definition, version, strict)
         except kubernetes_validate.utils.ValidationError as e:
             errors.append("resource definition validation error at %s: %s" % ('.'.join([str(item) for item in e.path]), e.message))  # noqa: B306
+        except kubernetes_validate.utils.VersionNotSupportedError as e:
+            errors.append("Kubernetes version %s is not supported by kubernetes-validate" % version)
         except kubernetes_validate.utils.SchemaNotFoundError as e:
             warnings.append("Could not find schema for object kind %s with API version %s in Kubernetes version %s (possibly Custom Resource?)" %
                             (e.kind, e.api_version, e.version))

--- a/openshift/dynamic/client.py
+++ b/openshift/dynamic/client.py
@@ -21,6 +21,11 @@ try:
 except ImportError:
     HAS_KUBERNETES_VALIDATE = False
 
+try:
+    from kubernetes_validate.utils import VersionNotSupportedError
+except ImportError:
+    class VersionNotSupportedError(NotImplementedError):
+        pass
 
 __all__ = [
     'DynamicClient',
@@ -335,7 +340,7 @@ class DynamicClient(object):
             kubernetes_validate.validate(definition, version, strict)
         except kubernetes_validate.utils.ValidationError as e:
             errors.append("resource definition validation error at %s: %s" % ('.'.join([str(item) for item in e.path]), e.message))  # noqa: B306
-        except kubernetes_validate.utils.VersionNotSupportedError as e:
+        except VersionNotSupportedError as e:
             errors.append("Kubernetes version %s is not supported by kubernetes-validate" % version)
         except kubernetes_validate.utils.SchemaNotFoundError as e:
             warnings.append("Could not find schema for object kind %s with API version %s in Kubernetes version %s (possibly Custom Resource?)" %


### PR DESCRIPTION
Return an error if validation is attempted against a very
old/very new version of kubernetes

This is an error to force the user to either upgrade/downgrade
their version of kubernetes-validate or turn off validation