### PR TITLE
add automatic caching for discovery requests, refreshing on a miss

### DIFF
--- a/openshift/dynamic/client.py
+++ b/openshift/dynamic/client.py
@@ -6,7 +6,7 @@ import copy
 import json
 import base64
 from functools import partial
-from six import PY2
+from six import PY2, PY3
 
 import yaml
 from pprint import pformat
@@ -93,7 +93,10 @@ class DynamicClient(object):
     def __init__(self, client, cache_file=None):
         self.client = client
         self.configuration = client.configuration
-        self.__cache_file = cache_file or '/tmp/osrcp-{0}.json'.format(base64.b64encode(self.configuration.host))
+        default_cache_id = self.configuration.host
+        if PY3:
+            default_cache_id = default_cache_id.encode('utf-8')
+        self.__cache_file = cache_file or '/tmp/osrcp-{0}.json'.format(base64.b64encode(default_cache_id).decode('utf-8'))
         self.__init_cache()
 
     def __init_cache(self, refresh=False):

--- a/openshift/dynamic/client.py
+++ b/openshift/dynamic/client.py
@@ -5,6 +5,7 @@ import sys
 import copy
 import json
 import base64
+import tempfile
 from functools import partial
 from six import PY2, PY3
 
@@ -96,8 +97,9 @@ class DynamicClient(object):
         default_cache_id = self.configuration.host
         if PY3:
             default_cache_id = default_cache_id.encode('utf-8')
+        default_cachefile_name = 'osrcp-{0}.json'.format(base64.b64encode(default_cache_id).decode('utf-8'))
         self.__resources = ResourceContainer({}, client=self)
-        self.__cache_file = cache_file or '/tmp/osrcp-{0}.json'.format(base64.b64encode(default_cache_id).decode('utf-8'))
+        self.__cache_file = cache_file or os.path.join(tempfile.gettempdir(), default_cachefile_name)
         self.__init_cache()
 
     def __init_cache(self, refresh=False):

--- a/openshift/dynamic/client.py
+++ b/openshift/dynamic/client.py
@@ -96,6 +96,7 @@ class DynamicClient(object):
         default_cache_id = self.configuration.host
         if PY3:
             default_cache_id = default_cache_id.encode('utf-8')
+        self.__resources = ResourceContainer({}, client=self)
         self.__cache_file = cache_file or '/tmp/osrcp-{0}.json'.format(base64.b64encode(default_cache_id).decode('utf-8'))
         self.__init_cache()
 
@@ -107,7 +108,7 @@ class DynamicClient(object):
             with open(self.__cache_file, 'r') as f:
                 self.__cache = json.load(f, cls=cache_decoder(self))
         self._load_server_info()
-        self.__resources = ResourceContainer(self.parse_api_groups(), client=self)
+        self.__resources.update(self.parse_api_groups())
 
         if refresh:
             self.__write_cache()
@@ -588,9 +589,12 @@ class ResourceContainer(object):
         easy searching and retrieval of specific resources
     """
 
-    def __init__(self, resources, client = None):
+    def __init__(self, resources, client=None):
         self.__resources = resources
         self.__client = client
+
+    def update(self, resources):
+        self.__resources = resources
 
     @property
     def api_groups(self):


### PR DESCRIPTION
This adds an automatic cache of discovery requests that is written to `/tmp/osrcp-${BASE_64_ENCODED_OPENSHIFT_HOST).json`.

This cache will persist until `invalidate_cache` is called manually, or until a resource is not found in the cache (making misses fairly expensive).

By necessity, also adds a  JSON encoder and decoder for the resources.

May conflict with changes in #220 , so @asetty would you mind taking a look and seeing if there's something I should do to make this play more nicely with your work?

For the Ansible modules, this should cut the number of requests per task down significantly.

I don't know much about caching so please be brutal in your feedback.