### PR TITLE
Reimplement list kinds to be more generic

### DIFF
--- a/openshift/dynamic/client.py
+++ b/openshift/dynamic/client.py
@@ -55,7 +55,7 @@ def cache_decoder(client):
             if _type == 'Resource':
                 return Resource(client=client, **obj)
             elif _type == 'ResourceList':
-                return ResourceList(obj['resource'])
+                return ResourceList(client, **obj)
             elif _type == 'ResourceGroup':
                 return ResourceGroup(obj['preferred'], resources=self.object_hook(obj['resources']))
             return obj
@@ -387,35 +387,96 @@ class Resource(object):
 class ResourceList(Resource):
     """ Represents a list of API objects """
 
-    def __init__(self, resource):
-        self.resource = resource
-        self.kind = '{}List'.format(resource.kind)
+    def __init__(self, client, group='', api_version='v1', base_kind='', kind=None):
+        self.client = client
+        self.group = group
+        self.api_version = api_version
+        self.kind = kind or '{}List'.format(base_kind)
+        self.base_kind = base_kind
+        self.__base_resource = None
 
-    def get(self, body=None, **kwargs):
+    def base_resource(self):
+        if self.__base_resource:
+            return self.__base_resource
+        elif self.base_kind:
+            self.__base_resource = self.client.resources.get(group=self.group, api_version=self.api_version, kind=self.base_kind)
+            return self.__base_resource
+        return None
+
+    def _items_to_resources(self, body):
+        """ Takes a List body and return a dictionary with the following structure:
+            {
+                'api_version': str,
+                'kind': str,
+                'items': [{
+                    'resource': Resource,
+                    'name': str,
+                    'namespace': str,
+                }]
+            }
+        """
         if body is None:
-            return self.resource.get(**kwargs)
+            raise ValueError("You must provide a body when calling methods on a ResourceList")
+
+        api_version = body['apiVersion']
+        kind = body['kind']
+        items = body.get('items')
+        if not items:
+            raise ValueError('The `items` field in the body must be populated when calling methods on a ResourceList')
+
+        if self.kind != kind:
+            raise ValueError('Methods on a {} must be called with a body containing the same kind. Receieved {} instead'.format(self.kind, kind))
+
+        return {
+            'api_version': api_version,
+            'kind': kind,
+            'items': [self._item_to_resource(item) for item in items]
+        }
+
+    def _item_to_resource(self, item):
+        metadata = item.get('metadata', {})
+        resource = self.base_resource()
+        if not resource:
+            api_version = item.get('apiVersion', self.api_version)
+            kind = item.get('kind', self.base_kind)
+            resource = self.client.resources.get(api_version=api_version, kind=kind)
+        return {
+            'resource': resource,
+            'definition': item,
+            'name': metadata.get('name'),
+            'namespace': metadata.get('namespace')
+        }
+
+    def get(self, body, name=None, namespace=None, **kwargs):
+        if name:
+            raise ValueError('Operations on ResourceList objects do not support the `name` argument')
+        resource_list = self._items_to_resources(body)
         response = copy.deepcopy(body)
-        namespace = kwargs.pop('namespace', None)
+
         response['items'] = [
-            self.resource.get(name=item['metadata']['name'], namespace=item['metadata'].get('namespace', namespace), **kwargs)
-            for item in body['items']
+            item['resource'].get(name=item['name'], namespace=item['namespace'] or namespace, **kwargs)
+            for item in resource_list['items']
         ]
         return ResourceInstance(self, response)
 
-    def delete(self, body=None, *args, **kwargs):
+    def delete(self, body, name=None, namespace=None, **kwargs):
+        if name:
+            raise ValueError('Operations on ResourceList objects do not support the `name` argument')
+        resource_list = self._items_to_resources(body)
         response = copy.deepcopy(body)
-        namespace = kwargs.pop('namespace', None)
+
         response['items'] = [
-            self.resource.delete(name=item['metadata']['name'], namespace=item['metadata'].get('namespace', namespace), **kwargs)
-            for item in body['items']
+            item['resource'].delete(name=item['name'], namespace=item['namespace'] or namespace, **kwargs)
+            for item in resource_list['items']
         ]
         return ResourceInstance(self, response)
 
-    def verb_mapper(self, verb, body=None, **kwargs):
+    def verb_mapper(self, verb, body, **kwargs):
+        resource_list = self._items_to_resources(body)
         response = copy.deepcopy(body)
         response['items'] = [
-            getattr(self.resource, verb)(body=item, **kwargs)
-            for item in body['items']
+            getattr(item['resource'], verb)(body=item['definition'], **kwargs)
+            for item in resource_list['items']
         ]
         return ResourceInstance(self, response)
 
@@ -428,14 +489,19 @@ class ResourceList(Resource):
     def patch(self, *args, **kwargs):
         return self.verb_mapper('patch', *args, **kwargs)
 
-    def __getattr__(self, name):
-        return getattr(self.resource, name)
-
     def to_dict(self):
         return {
             '_type': 'ResourceList',
-            'resource': self.resource.to_dict(),
+            'group': self.group,
+            'api_version': self.api_version,
+            'kind': self.kind,
+            'base_kind': self.base_kind
         }
+
+    def __getattr__(self, name):
+        if self.base_resource():
+            return getattr(self.base_resource(), name)
+        return None
 
 
 class Subresource(Resource):
@@ -578,6 +644,7 @@ class Discoverer(object):
             groups_response = load_json(self.client.request('GET', '/{}'.format(prefix)))['groups']
 
             groups = self.default_groups(request_resources=request_resources)
+            groups['api']['']['v1']['List'] = ResourceList(self)
             groups[prefix] = {}
 
             for group in groups_response:
@@ -631,8 +698,10 @@ class Discoverer(object):
                 client=self.client,
                 preferred=preferred,
                 subresources=subresources.get(resource['name']),
-                **resource)
-            resources['{}List'.format(resource['kind'])] = ResourceList(resources[resource['kind']])
+                **resource
+            )
+            resource_list = ResourceList(self, group=group, api_version=version, base_kind=resource['kind'])
+            resources[resource_list.kind] = resource_list
         return resources
 
     def get(self, **kwargs):

--- a/openshift/dynamic/client.py
+++ b/openshift/dynamic/client.py
@@ -7,9 +7,9 @@ import json
 import base64
 import tempfile
 from functools import partial
-from six import PY2, PY3
 from abc import abstractmethod, abstractproperty
 
+import six
 import yaml
 from pprint import pformat
 
@@ -82,12 +82,12 @@ def serialize(resource, response):
     try:
         return ResourceInstance(resource, load_json(response))
     except ValueError:
-        if PY2:
+        if six.PY2:
             return response.data
         return response.data.decode('utf8')
 
 def load_json(response):
-    if PY2:
+    if six.PY2:
         return json.loads(response.data)
     return json.loads(response.data.decode('utf8'))
 
@@ -582,7 +582,7 @@ class Discoverer(object):
     def __init__(self, client, cache_file):
         self.client = client
         default_cache_id = self.client.configuration.host
-        if PY3:
+        if six.PY3:
             default_cache_id = default_cache_id.encode('utf-8')
         default_cachefile_name = 'osrcp-{0}.json'.format(base64.b64encode(default_cache_id).decode('utf-8'))
         self.__cache_file = cache_file or os.path.join(tempfile.gettempdir(), default_cachefile_name)
@@ -809,7 +809,7 @@ class LazyDiscoverer(Discoverer):
                             prefix, group, version, rg.preferred)
                         self._cache['resources'][prefix][group][version] = rg
                         self.__update_cache = True
-                    for _, resource in rg.resources.items():
+                    for _, resource in six.iteritems(rg.resources):
                         yield resource
         self.__maybe_write_cache()
 

--- a/test/functional/dynamic/create.feature
+++ b/test/functional/dynamic/create.feature
@@ -1,9 +1,10 @@
 Feature: Create
 
     Examples:
-    | filename                         | namespace |
-    | definitions/v1_Pod_test.yaml     | test      |
-    | definitions/v1_PodList_test.yaml | test2     |
+    | filename                         | namespace    |
+    | definitions/v1_Pod_test.yaml     | test-create  |
+    | definitions/v1_PodList_test.yaml | test-create2 |
+    | definitions/v1_List_test.yaml    | test-create  |
 
 
     Scenario Outline: Create a resource for the first time

--- a/test/functional/dynamic/definitions/v1_List_test.yaml
+++ b/test/functional/dynamic/definitions/v1_List_test.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: List
+items:
+- kind: ConfigMap
+  apiVersion: v1
+  metadata:
+    name: test-config1
+  data:
+    index: "1"
+- kind: ConfigMap
+  apiVersion: v1
+  metadata:
+    name: test-config2
+  data:
+    index: "2"

--- a/test/functional/dynamic/definitions/v1_List_test_replace.yaml
+++ b/test/functional/dynamic/definitions/v1_List_test_replace.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: List
+items:
+- kind: ConfigMap
+  apiVersion: v1
+  metadata:
+    name: test-config1
+  data:
+    overwritten: "true"
+- kind: ConfigMap
+  apiVersion: v1
+  metadata:
+    name: test-config2
+  data:
+    overwritten: "true"

--- a/test/functional/dynamic/delete.feature
+++ b/test/functional/dynamic/delete.feature
@@ -1,9 +1,10 @@
 Feature: Delete
 
     Examples:
-    | filename                         | namespace |
-    | definitions/v1_Pod_test.yaml     | test      |
-    | definitions/v1_PodList_test.yaml | test2     |
+    | filename                         | namespace    |
+    | definitions/v1_Pod_test.yaml     | test-delete  |
+    | definitions/v1_PodList_test.yaml | test-delete2 |
+    | definitions/v1_List_test.yaml    | test-delete  |
 
     Scenario Outline: Delete a resource that exists
         Given I have edit permissions in <namespace>

--- a/test/functional/dynamic/patch.feature
+++ b/test/functional/dynamic/patch.feature
@@ -1,9 +1,10 @@
 Feature: Patch
 
     Examples:
-    | filename                         | namespace       | update                                 |
-    | definitions/v1_Pod_test.yaml     | test-patch      | definitions/v1_Pod_test_patch.yaml     |
-    | definitions/v1_PodList_test.yaml | test-patch2     | definitions/v1_PodList_test_patch.yaml |
+    | filename                         | namespace   | update                                 |
+    | definitions/v1_Pod_test.yaml     | test-patch  | definitions/v1_Pod_test_patch.yaml     |
+    | definitions/v1_PodList_test.yaml | test-patch2 | definitions/v1_PodList_test_patch.yaml |
+    | definitions/v1_List_test.yaml    | test-patch  | definitions/v1_List_test_replace.yaml  |
 
     Scenario Outline: Patch a resource that does not exist
         Given I have edit permissions in <namespace>

--- a/test/functional/dynamic/replace.feature
+++ b/test/functional/dynamic/replace.feature
@@ -1,9 +1,10 @@
 Feature: Replace
 
     Examples:
-    | filename                                              | namespace    | update                                                        |
-    | definitions/route.openshift.io_v1_Route_test.yaml     | test-replace | definitions/route.openshift.io_v1_Route_test_replace.yaml     |
-    | definitions/route.openshift.io_v1_RouteList_test.yaml | test-replace | definitions/route.openshift.io_v1_RouteList_test_replace.yaml |
+    | filename                                              | namespace     | update                                                        |
+    | definitions/route.openshift.io_v1_Route_test.yaml     | test-replace  | definitions/route.openshift.io_v1_Route_test_replace.yaml     |
+    | definitions/route.openshift.io_v1_RouteList_test.yaml | test-replace2 | definitions/route.openshift.io_v1_RouteList_test_replace.yaml |
+    | definitions/v1_List_test.yaml                         | test-replace  | definitions/v1_List_test_replace.yaml                         |
 
     Scenario Outline: Replace a resource that does not exist
         Given I have edit permissions in <namespace>

--- a/test/unit/test_discoverer.py
+++ b/test/unit/test_discoverer.py
@@ -29,7 +29,9 @@ def mock_namespace():
 
 @pytest.fixture(scope='module')
 def mock_namespace_list(mock_namespace):
-    return ResourceList(mock_namespace)
+    ret = ResourceList(mock_namespace.client, mock_namespace.group, mock_namespace.api_version, mock_namespace.kind)
+    ret._ResourceList__base_resource = mock_namespace
+    return ret
 
 
 @pytest.fixture(scope='function', autouse=True)


### PR DESCRIPTION
This implementation will support both typed and untyped List kinds, and we now automatically add the fake `v1.List` resource during discovery.

Should fix one of the issues brought up in https://github.com/redhat-cop/openshift-applier/issues/39, also recorded in https://github.com/ansible/ansible/issues/49100, and will close #209 