### PR TITLE
Lower case URLs

### DIFF
--- a/openshift/dynamic/client.py
+++ b/openshift/dynamic/client.py
@@ -358,11 +358,12 @@ class Resource(object):
     @property
     def urls(self):
         full_prefix = '{}/{}'.format(self.prefix, self.group_version)
+        resource_name = self.name.lower()
         return {
-            'base': '/{}/{}'.format(full_prefix, self.name),
-            'namespaced_base': '/{}/namespaces/{{namespace}}/{}'.format(full_prefix, self.name),
-            'full': '/{}/{}/{{name}}'.format(full_prefix, self.name),
-            'namespaced_full': '/{}/namespaces/{{namespace}}/{}/{{name}}'.format(full_prefix, self.name)
+            'base': '/{}/{}'.format(full_prefix, resource_name),
+            'namespaced_base': '/{}/namespaces/{{namespace}}/{}'.format(full_prefix, resource_name),
+            'full': '/{}/{}/{{name}}'.format(full_prefix, resource_name),
+            'namespaced_full': '/{}/namespaces/{{namespace}}/{}/{{name}}'.format(full_prefix, resource_name)
         }
 
     def path(self, name=None, namespace=None):


### PR DESCRIPTION
This matches the behavior of `kubectl`, which is able to handle resources that improperly report their name camelCase. More investigation is required to verify that this doesn't break any other behavior (ie, is it safe to always lowercase the full url, or should only name be lowercased?)