### PR TITLE
Make list from kind resource item

### DIFF
--- a/test/unit/test_resource_container.py
+++ b/test/unit/test_resource_container.py
@@ -4,6 +4,33 @@ from kubernetes.client import ApiClient
 
 from openshift.dynamic import DynamicClient, Resource, ResourceList
 
+@pytest.fixture(scope='module')
+def mock_templates():
+    return Resource(
+        api_version='v1',
+        kind='Template',
+        name='templates',
+        namespaced=True,
+        preferred=True,
+        prefix='api',
+        shorter_names=[],
+        shortNames=[],
+        verbs=['create', 'delete', 'get', 'list', 'patch', 'update', 'watch']
+    )
+
+@pytest.fixture(scope='module')
+def mock_processedtemplates():
+    return Resource(
+        api_version='v1',
+        kind='Template',
+        name='processedtemplates',
+        namespaced=True,
+        preferred=True,
+        prefix='api',
+        shorter_names=[],
+        shortNames=[],
+        verbs=['create', 'delete', 'get', 'list', 'patch', 'update', 'watch']
+    )
 
 @pytest.fixture(scope='module')
 def mock_namespace():
@@ -26,7 +53,7 @@ def mock_namespace_list(mock_namespace):
     return ResourceList(mock_namespace)
 
 @pytest.fixture(scope='function', autouse=True)
-def setup_client_monkeypatch(monkeypatch, mock_namespace, mock_namespace_list):
+def setup_client_monkeypatch(monkeypatch, mock_namespace, mock_namespace_list, mock_templates, mock_processedtemplates):
 
     def mock_load_server_info(self):
         self.__version = {'kubernetes': 'mock-k8s-version'}
@@ -36,8 +63,9 @@ def setup_client_monkeypatch(monkeypatch, mock_namespace, mock_namespace_list):
             'api': {
                 '': {
                     'v1': {
-                        'Namespace': mock_namespace,
-                        'NamespaceList': mock_namespace_list
+                        'Namespace': [mock_namespace],
+                        'NamespaceList': [mock_namespace_list],
+                        'Template': [mock_templates, mock_processedtemplates],
                     }
                 }
             }
@@ -80,3 +108,10 @@ def test_get_namespace_list_kind(client, mock_namespace_list):
     resource = client.resources.get(api_version='v1', kind='NamespaceList')
 
     assert resource == mock_namespace_list
+
+def test_search_multiple_resources_for_template(client, mock_templates, mock_processedtemplates):
+    resources = client.resources.search(api_version='v1', kind='Template')
+
+    assert len(resources) == 2
+    assert mock_templates in resources
+    assert mock_processedtemplates in resources


### PR DESCRIPTION
This is backport of: https://github.com/openshift/openshift-restclient-python/pull/272

Previously when creating a resource list, kind was a dictionary meaning
that there could be only one resource for specific kind. But for example
Template kind can have two different resources:

```
$ oc api-resources | grep Template$
processedtemplates template.openshift.io true Template
templates.         template.openshift.io true Template
```

So The client previsously found just one resource for kind Template.
In order to work with both resources for that kind this patch introduces
the change that kind will be list by default.