### PR TITLE
Don't use cache when listing api_groups

### DIFF
--- a/openshift/dynamic/client.py
+++ b/openshift/dynamic/client.py
@@ -615,7 +615,7 @@ class ResourceContainer(object):
     @property
     def api_groups(self):
         """ list available api groups """
-        return self.__resources['apis'].keys()
+        return [group['name'] for group in load_json(self.__client.request("GET", '/apis'))['groups']]
 
     def get(self, **kwargs):
         """ Same as search, but will throw an error if there are multiple or no

--- a/openshift/helper/base.py
+++ b/openshift/helper/base.py
@@ -609,28 +609,27 @@ class BaseObjectHelper(object):
                         # Object is either added or modified. Check the status and determine if we
                         #  should continue waiting
                         if hasattr(obj, 'status'):
-                            status = getattr(obj, 'status')
-                            if hasattr(status, 'phase'):
-                                if status.phase == 'Active':
+                            if hasattr(obj.status, 'phase'):
+                                if obj.status.phase == 'Active':
                                     # TODO other phase values ??
                                     # TODO test namespaces for OpenShift annotations if needed
                                     return_obj = obj
                                     watcher.stop()
                                     break
-                            elif hasattr(status, 'conditions'):
-                                conditions = getattr(status, 'conditions')
+                            elif hasattr(obj.status, 'conditions'):
+                                conditions = obj.status.conditions
                                 if conditions and len(conditions) > 0:
                                     # We know there is a status, but it's up to the user to determine meaning.
                                     return_obj = obj
                                     watcher.stop()
                                     break
-                            elif obj.kind == 'Service' and status is not None:
+                            elif obj.kind == 'Service' and obj.status is not None:
                                 return_obj = obj
                                 watcher.stop()
                                 break
                             elif obj.kind == 'Route':
                                 route_statuses = set()
-                                for route_ingress in status.ingress:
+                                for route_ingress in obj.status.ingress:
                                     for condition in route_ingress.conditions:
                                         route_statuses.add(condition.type)
                                 if route_statuses <= {'Ready', 'Admitted'}:


### PR DESCRIPTION
Spiritual backport of #264, but since there has been so much change between 0.8 and master going with this simpler fix. Will just request api_groups every time the method is called. This prevents the `check for CustomResourceDefinition` -> `create CRD because it wasn't there` -> `check CRD again, still says it's not there because API groups are cached and querying api_groups doesn't register as a miss` issue.