### PR TITLE
Fixes for Ansible apply

### DIFF
--- a/openshift/dynamic/apply.py
+++ b/openshift/dynamic/apply.py
@@ -14,9 +14,9 @@ def apply(resource, definition):
         )
     )
     try:
-        actual = resource.get(name=definition['metadata']['name'], namespace=definition['metadata']['namespace'])
+        actual = resource.get(name=definition['metadata']['name'], namespace=definition['metadata'].get('namespace'))
     except NotFoundError:
-        return resource.create(body=dict_merge(definition, desired_annotation), namespace=definition['metadata']['namespace'])
+        return resource.create(body=dict_merge(definition, desired_annotation), namespace=definition['metadata'].get('namespace'))
     last_applied = actual.metadata.get('annotations',{}).get(LAST_APPLIED_CONFIG_ANNOTATION)
 
     if last_applied:
@@ -27,12 +27,12 @@ def apply(resource, definition):
         if patch:
             return resource.patch(body=dict_merge(patch, desired_annotation),
                                   name=definition['metadata']['name'],
-                                  namespace=definition['metadata']['namespace'],
+                                  namespace=definition['metadata'].get('namespace'),
                                   content_type='application/merge-patch+json')
         else:
             return actual
     else:
-        return resource.patch(body=definition, name=definition['metadata']['name'], namespace=definition['metadata']['namespace'])
+        return resource.patch(body=definition, name=definition['metadata']['name'], namespace=definition['metadata'].get('namespace'))
 
 
 # The patch is the difference from actual to desired without deletions, plus deletions

--- a/openshift/dynamic/client.py
+++ b/openshift/dynamic/client.py
@@ -177,7 +177,6 @@ class DynamicClient(object):
 
         return self.request('patch', path, body=body, content_type=content_type, **kwargs)
 
-    @meta_request
     def apply(self, resource, body=None, name=None, namespace=None):
         body = self.serialize_body(body)
         name = name or body.get('metadata', {}).get('name')


### PR DESCRIPTION
Namespace needs to be an optional key

Adding @meta_request to apply seems to cause a double serialization once it then goes on to call resource.patch or resource.create