### PR TITLE
always use merge-patch+json in apply

### DIFF
--- a/openshift/dynamic/apply.py
+++ b/openshift/dynamic/apply.py
@@ -32,7 +32,11 @@ def apply(resource, definition):
         else:
             return actual
     else:
-        return resource.patch(body=definition, name=definition['metadata']['name'], namespace=definition['metadata'].get('namespace'))
+        return resource.patch(
+            body=definition,
+            name=definition['metadata']['name'],
+            namespace=definition['metadata'].get('namespace'),
+            content_type='application/merge-patch+json')
 
 
 # The patch is the difference from actual to desired without deletions, plus deletions


### PR DESCRIPTION
This will let `apply` work with all resources, including ones defined by `CustomResourceDefinition`s, even when the resource was not created with `apply`