### PR TITLE
Always set apiVersion and kind for resources within a resource list

### DIFF
--- a/openshift/dynamic/client.py
+++ b/openshift/dynamic/client.py
@@ -979,6 +979,17 @@ class ResourceInstance(object):
 
     def __init__(self, resource, instance):
         self.resource_type = resource
+        # If we have a list of resources, then set the apiVersion and kind of
+        # each resource in 'items'
+        kind = instance['kind']
+        if kind.endswith('List') and 'items' in instance:
+            kind = instance['kind'][:-4]
+            for item in instance['items']:
+                if 'apiVersion' not in item:
+                    item['apiVersion'] = instance['apiVersion']
+                if 'kind' not in item:
+                    item['kind'] = kind
+
         self.attributes = self.__deserialize(instance)
 
     def __deserialize(self, field):


### PR DESCRIPTION
When the Kubernetes REST API returns a list of objects, it returns a
resource list object with an apiVersion and kind set to "KindList" where
"Kind" is the Kind of object queried, rather than an simple array of
objects.

The `items` property contains the array of resources returned.  Each
resource in this list does not contain the GVK information, only the
resource list has an apiVersion or kind property set.

This ensures when a resource list is returned, each resource within the
list has it's apiVersion and kind set, to make it similar to other
Kubernetes clients, and easier to work with the returned resources.

My primary reason for contributing this is because in the k8s_facts module in
Ansible pulls the `items` out of a resource list
(https://github.com/ansible/ansible/blob/devel/lib/ansible/module_utils/k8s/common.py#L211-L212), but each item in a resource
list doesn't have the apiVersion/kind information, only the list object itself
does, so you can't inspect the
kind of the objects returned, which is problematic.