### PR TITLE
Ensure that namespace and name parameters are used for apply

### DIFF
--- a/openshift/dynamic/client.py
+++ b/openshift/dynamic/client.py
@@ -179,11 +179,12 @@ class DynamicClient(object):
 
     def apply(self, resource, body=None, name=None, namespace=None):
         body = self.serialize_body(body)
-        name = name or body.get('metadata', {}).get('name')
+        body['metadata'] = body.get('metadata', dict())
+        name = name or body['metadata'].get('name')
         if not name:
             raise ValueError("name is required to apply {}.{}".format(resource.group_version, resource.kind))
         if resource.namespaced:
-            namespace = self.ensure_namespace(resource, namespace, body)
+            body['metadata']['namespace'] = self.ensure_namespace(resource, namespace, body)
         return apply(resource, body)
 
     def watch(self, resource, namespace=None, name=None, label_selector=None, field_selector=None, resource_version=None, timeout=None):


### PR DESCRIPTION
resource definitions that are accompanied separately by names
and namespaces should be updated and the name and namespace used

Fixes #296