### PR TITLE
Remove dependency version locks from master

### DIFF
--- a/openshift/dynamic/client.py
+++ b/openshift/dynamic/client.py
@@ -311,7 +311,7 @@ class DynamicClient(object):
             kubernetes_validate.validate(definition, version, strict)
         except kubernetes_validate.utils.ValidationError as e:
             errors.append("resource definition validation error at %s: %s" % ('.'.join([str(item) for item in e.path]), e.message))  # noqa: B306
-        except VersionNotSupportedError as e:
+        except VersionNotSupportedError:
             errors.append("Kubernetes version %s is not supported by kubernetes-validate" % version)
         except kubernetes_validate.utils.SchemaNotFoundError as e:
             warnings.append("Could not find schema for object kind %s with API version %s in Kubernetes version %s (possibly Custom Resource?)" %

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 dictdiffer
 jinja2
-kubernetes ~= 9.0.0
-urllib3 < 1.25
+kubernetes
 python-string-utils
-ruamel.yaml >= 0.15
+ruamel.yaml
 six

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,8 +1,8 @@
-coverage>=3.7.1
-docker ~= 2.1.0
-flake8 < 3.6.0
-pytest < 3.3
+coverage
+docker
+flake8
+pytest
 pytest-bdd
-pytest-cov < 2.6
+pytest-cov
 PyYAML
 dictdiffer

--- a/test/functional/conftest.py
+++ b/test/functional/conftest.py
@@ -88,7 +88,13 @@ def kubeconfig(openshift_container, tmpdir_factory):
         openshift_container.exec_run('oc login -u test -p test')
         tar_stream, _ = openshift_container.get_archive(
             '/var/lib/origin/openshift.local.config/master/admin.kubeconfig')
-        tar_obj = tarfile.open(fileobj=io.BytesIO(tar_stream.read()))
+
+        tar_bytes = io.BytesIO()
+        for chunk in tar_stream:
+            tar_bytes.write(chunk)
+        tar_bytes.seek(0)
+
+        tar_obj = tarfile.open(fileobj=tar_bytes)
         kubeconfig_contents = tar_obj.extractfile('admin.kubeconfig').read()
 
         kubeconfig_file = tmpdir_factory.mktemp('kubeconfig').join('admin.kubeconfig')
@@ -106,7 +112,13 @@ def admin_kubeconfig(openshift_container, tmpdir_factory):
         openshift_container.exec_run('oc login -u system:admin')
         tar_stream, _ = openshift_container.get_archive(
             '/var/lib/origin/openshift.local.config/master/admin.kubeconfig')
-        tar_obj = tarfile.open(fileobj=io.BytesIO(tar_stream.read()))
+
+        tar_bytes = io.BytesIO()
+        for chunk in tar_stream:
+            tar_bytes.write(chunk)
+        tar_bytes.seek(0)
+
+        tar_obj = tarfile.open(fileobj=tar_bytes)
         kubeconfig_contents = tar_obj.extractfile('admin.kubeconfig').read()
 
         kubeconfig_file = tmpdir_factory.mktemp('kubeconfig').join('admin.kubeconfig')

--- a/test/functional/conftest.py
+++ b/test/functional/conftest.py
@@ -53,9 +53,9 @@ def openshift_container(request, port, pytestconfig):
             # Wait for the container to no longer be in the created state before
             # continuing
             while container.status == u'created':
-                capmanager.suspendcapture()
+                capmanager.suspend()
                 print("\nWaiting for container...")
-                capmanager.resumecapture()
+                capmanager.resume()
                 time.sleep(5)
                 container = client.containers.get(container.id)
 


### PR DESCRIPTION
Master should be taking in latest dependencies so that we can quickly find out and take action if a dependency has broken us. This will also help our dependencies from getting to stale across releases. 
Additional infrastructure to automate version pinning for releases would be handy, need to learn about what the best practices are for that.

First step to fixing #289 