### PR TITLE
[release-0.9] remove pinned urllib3 dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 dictdiffer
 jinja2
 kubernetes ~= 9.0.0
-urllib3 < 1.25
 python-string-utils
 ruamel.yaml >= 0.15
 six


### PR DESCRIPTION
Addresses https://github.com/openshift/openshift-restclient-python/issues/289#issuecomment-495808399