### PR TITLE
Prevent cache-related module failures

### DIFF
--- a/openshift/dynamic/discovery.py
+++ b/openshift/dynamic/discovery.py
@@ -26,12 +26,22 @@ class Discoverer(object):
 
     def __init__(self, client, cache_file):
         self.client = client
-        default_cache_id = self.client.configuration.host
-        if six.PY3:
-            default_cache_id = default_cache_id.encode('utf-8')
-        default_cachefile_name = 'osrcp-{0}.json'.format(hashlib.md5(default_cache_id).hexdigest())
+        default_cachefile_name = 'osrcp-{0}.json'.format(hashlib.md5(self.__get_default_cache_id()).hexdigest())
         self.__cache_file = cache_file or os.path.join(tempfile.gettempdir(), default_cachefile_name)
         self.__init_cache()
+
+    def __get_default_cache_id(self):
+        user = ""
+        for func in [os.getlogin, os.getuid]:
+            try:
+                user = str(func())
+            except OSError:
+                pass
+
+        cache_id = "{0}-{1}".format(self.client.configuration.host, user)
+        if six.PY3:
+            return cache_id.encode('utf-8')
+        return cache_id
 
     def __init_cache(self, refresh=False):
         if refresh or not os.path.exists(self.__cache_file):

--- a/openshift/dynamic/discovery.py
+++ b/openshift/dynamic/discovery.py
@@ -62,8 +62,12 @@ class Discoverer(object):
             self._write_cache()
 
     def _write_cache(self):
-        with open(self.__cache_file, 'w') as f:
-            json.dump(self._cache, f, cls=CacheEncoder)
+        try:
+            with open(self.__cache_file, 'w') as f:
+                json.dump(self._cache, f, cls=CacheEncoder)
+        except Exception:
+            # Failing to write the cache shouldn't crash the library
+            pass
 
     def invalidate_cache(self):
         self.__init_cache(refresh=True)


### PR DESCRIPTION
- Use the user's name or uid as part of the cache name. This will prevent cache name collisions across users on the same machine, as described in https://github.com/ansible/ansible/issues/55430#issuecomment-504065472
- No longer crashes if the cache fails to write

