### PR TITLE
Ignore ServiceUnavailableError for an all resource group search

### DIFF
--- a/openshift/dynamic/discovery.py
+++ b/openshift/dynamic/discovery.py
@@ -9,7 +9,7 @@ from abc import abstractmethod, abstractproperty
 from urllib3.exceptions import ProtocolError, MaxRetryError
 
 from openshift import __version__
-from .exceptions import ResourceNotFoundError, ResourceNotUniqueError, ApiException
+from .exceptions import ResourceNotFoundError, ResourceNotUniqueError, ApiException, ServiceUnavailableError
 from .resource import Resource, ResourceList
 
 
@@ -182,7 +182,10 @@ class Discoverer(object):
         subresources = {}
 
         path = '/'.join(filter(None, [prefix, group, version]))
-        resources_response = self.client.request('GET', path).resources or []
+        try:
+            resources_response = self.client.request('GET', path).resources or []
+        except ServiceUnavailableError:
+            resources_response = []
 
         resources_raw = list(filter(lambda resource: '/' not in resource['name'], resources_response))
         subresources_raw = list(filter(lambda resource: '/' in resource['name'], resources_response))


### PR DESCRIPTION
There are situations where a given api service unrelated to the
requested resource is unavailable and an ServiceUnavailableError
exception is thrown.

The change in this PR will allow resources to be found if the
resource being requested is unrelated to an api service that is
unavailable.

Resolves https://github.com/openshift/openshift-restclient-python/issues/349