### PR TITLE
Fix apply to cope better with missing last_applied entries

### DIFF
--- a/openshift/dynamic/apply.py
+++ b/openshift/dynamic/apply.py
@@ -207,11 +207,11 @@ def get_delta(last_applied, actual, desired, position=None):
         if actual_value is None:
             patch[k] = desired_value
         elif isinstance(desired_value, dict):
-            p = get_delta(last_applied.get(k), actual_value, desired_value, this_position)
+            p = get_delta(last_applied.get(k, {}), actual_value, desired_value, this_position)
             if p:
                 patch[k] = p
         elif isinstance(desired_value, list):
-            p = list_merge(last_applied.get(k), actual_value, desired_value, this_position)
+            p = list_merge(last_applied.get(k, []), actual_value, desired_value, this_position)
             if p:
                 patch[k] = [item for item in p if item]
         elif actual_value != desired_value:

--- a/test/unit/test_apply.py
+++ b/test/unit/test_apply.py
@@ -283,6 +283,37 @@ tests = [
                 }
             }
         }
+    ),
+    dict(
+        last_applied = {
+            'kind': 'MadeUp',
+            'toplevel': {
+                'original': 'entry'
+            }
+        },
+        actual = {
+            'kind': 'MadeUp',
+            'toplevel': {
+                'original': 'entry',
+                'another': {
+                    'nested': {
+                         'entry': 'value'
+                    }
+                }
+            }
+        },
+        desired = {
+            'kind': 'MadeUp',
+            'toplevel': {
+                'original': 'entry',
+                'another': {
+                    'nested': {
+                         'entry': 'value'
+                    }
+                }
+            }
+        },
+        expected = {}
     )
 ]
 


### PR DESCRIPTION
If desired and actual contain a dict structure that is missing
from last_applied, continue rather than crashing with

AttributeError: 'NoneType' object has no attribute 'get'