### PR TITLE
Handle dryRun, and pass that on as a query param.

### DIFF
--- a/openshift/dynamic/client.py
+++ b/openshift/dynamic/client.py
@@ -211,7 +211,7 @@ class DynamicClient(object):
         if params.get('watch') is not None:
             query_params.append(('watch', params['watch']))
         if params.get('dryRun') is not None:
-            query_params.append(('dryRun', params['dryRun']))
+            query_params.append(('dryRun', params['dry_run']))
 
         header_params = params.get('header_params', {})
         form_params = []

--- a/openshift/dynamic/client.py
+++ b/openshift/dynamic/client.py
@@ -210,7 +210,7 @@ class DynamicClient(object):
             query_params.append(('timeoutSeconds', params['timeout_seconds']))
         if params.get('watch') is not None:
             query_params.append(('watch', params['watch']))
-        if params.get('dryRun') is not None:
+        if params.get('dry_run') is not None:
             query_params.append(('dryRun', params['dry_run']))
 
         header_params = params.get('header_params', {})

--- a/openshift/dynamic/client.py
+++ b/openshift/dynamic/client.py
@@ -210,6 +210,8 @@ class DynamicClient(object):
             query_params.append(('timeoutSeconds', params['timeout_seconds']))
         if params.get('watch') is not None:
             query_params.append(('watch', params['watch']))
+        if params.get('dryRun') is not None:
+            query_params.append(('dryRun', params['dryRun']))
 
         header_params = params.get('header_params', {})
         form_params = []


### PR DESCRIPTION
This is a fix to support dry run. This is the issue - https://github.com/openshift/openshift-restclient-python/issues/361