### PR TITLE
Handle list merges where items have been added elsewhere

### DIFF
--- a/openshift/dynamic/apply.py
+++ b/openshift/dynamic/apply.py
@@ -178,6 +178,9 @@ def list_merge(last_applied, actual, desired, position):
             else:
                 patch = merge(last_applied_dict[key], desired_dict[key], actual_dict[key], position)
                 result.append(dict_merge(actual_dict[key], patch))
+        for key in actual_dict:
+            if key not in desired_dict and key not in last_applied_dict:
+                result.append(actual_dict[key])
         return result
     else:
         return desired

--- a/test/unit/test_apply.py
+++ b/test/unit/test_apply.py
@@ -53,6 +53,7 @@ tests = [
         ),
         expected = dict(metadata=dict(annotations=None), data=dict(two=None, three="3"))
     ),
+
     dict(
         last_applied = dict(
             kind="Service",
@@ -164,6 +165,43 @@ tests = [
         ),
         expected=dict(spec=dict(containers=[dict(name="busybox", image="busybox",
                                                  resources=dict(requests=dict(cpu="50m", memory="50Mi"), limits=dict(cpu=None, memory="50Mi")))]))
+    ),
+    dict(
+        desired = dict(kind='Pod',
+                       spec=dict(containers=[
+                           dict(name='hello',
+                                volumeMounts=[dict(name="test", mountPath="/test")])
+                           ],
+                           volumes=[
+                               dict(name="test", configMap=dict(name="test")),
+                           ])),
+        last_applied = dict(kind='Pod',
+                       spec=dict(containers=[
+                           dict(name='hello',
+                                volumeMounts=[dict(name="test", mountPath="/test")])
+                           ],
+                           volumes=[
+                               dict(name="test", configMap=dict(name="test")),
+                           ])),
+        actual = dict(kind='Pod',
+                       spec=dict(containers=[
+                           dict(name='hello',
+                                volumeMounts=[dict(name="test", mountPath="/test"),
+                                              dict(mountPath="/var/run/secrets/kubernetes.io/serviceaccount", name="default-token-xyz")])
+                           ],
+                           volumes=[
+                               dict(name="test", configMap=dict(name="test")),
+                               dict(name="default-token-xyz", secret=dict(secretName="default-token-xyz")),
+                           ])),
+        expected = dict(spec=dict(containers=[
+                           dict(name='hello',
+                                volumeMounts=[dict(name="test", mountPath="/test"),
+                                              dict(mountPath="/var/run/secrets/kubernetes.io/serviceaccount", name="default-token-xyz")])
+                           ],
+                           volumes=[
+                               dict(name="test", configMap=dict(name="test")),
+                               dict(name="default-token-xyz", secret=dict(secretName="default-token-xyz")),
+                           ])),
     ),
 
     # This next one is based on a real world case where definition was mostly


### PR DESCRIPTION
For example, a Pod has its service account token mounted as
a volume - we don't want to later try and remove it.

Other examples are likely available