### PR TITLE
Sync release-0.6 branch with what is in the 0.6.2-12 RPM

### DIFF
--- a/.tito/releasers.conf
+++ b/.tito/releasers.conf
@@ -13,18 +13,6 @@ remote_location = http://repos.fedorapeople.org/asb/
 copr_options = --timeout 600
 builder.test = 1
 
-[asb-brew-36]
+[asb-brew]
 releaser = tito.release.DistGitReleaser
-branches = rhaos-3.6-asb-rhel-7
-
-[asb-brew-37]
-releaser = tito.release.DistGitReleaser
-branches = rhaos-3.7-asb-rhel-7
-
-[asb-brew-38]
-releaser = tito.release.DistGitReleaser
-branches = rhaos-3.8-asb-rhel-7
-
-[asb-brew-39]
-releaser = tito.release.DistGitReleaser
-branches = rhaos-3.9-asb-rhel-7
+branches = rhaos-3.11-asb-rhel-7

--- a/openshift/client/api_client.py
+++ b/openshift/client/api_client.py
@@ -11,7 +11,7 @@ from . import models
 class ApiClient(K8sApiClient):
     def _ApiClient__deserialize(self, data, klass):
         if klass == 'RuntimeRawExtension':
-            data = {'Raw': b64encode(json.dumps(data))}
+            data = {'Raw': b64encode(json.dumps(data).encode())}
         try:
             return super(ApiClient, self).__deserialize(data, klass)
         except AttributeError:

--- a/openshift/client/api_client.py
+++ b/openshift/client/api_client.py
@@ -11,7 +11,7 @@ from . import models
 class ApiClient(K8sApiClient):
     def _ApiClient__deserialize(self, data, klass):
         if klass == 'RuntimeRawExtension':
-            data = {'Raw': b64encode(json.dumps(data).encode())}
+            data = {'Raw': b64encode(json.dumps(data).encode()).decode()}
         try:
             return super(ApiClient, self).__deserialize(data, klass)
         except AttributeError:


### PR DESCRIPTION
The 0.6.2-12 RPM release was apparently made from the `release-0.7` branch by mistake back in 2018. 
The  `release-0.7` commits are below
```
2018-08-06 15:41 -0400 David Zager                o [0.6.2] <python-openshift-0.6.2-12> Automatic commit of package [python-openshift] minor release [0.6.2-12].
2018-08-02 09:08 -0500 Andrew DeMaria             o Fix decode issue (#192)
2018-07-30 10:39 +0200 Fridolin Pokorny           o b64encode expects bytes not string
2018-07-23 15:55 -0400 Jason Montleon             M─┐ Merge pull request #185 from djzager/update-releasers
2018-07-23 15:51 -0400 David Zager                │ o Update releasers for 3.11
2018-07-23 15:49 -0400 David Zager                o─┘ <python-openshift-0.6.2-11> Automatic commit of package [python-openshift] minor release [0.6.2-11].
2018-07-13 14:46 -0400 Fabian von Feilitzsch      o include version update script
2018-07-13 14:45 -0400 Fabian von Feilitzsch      o Version bump to 0.6.2
```
The current `release-0.6` commits look like this:
```
2019-10-23 13:53 -0400 Fabian von Feilitzsch      o [release-0.6] {upstream/release-0.6} <0.6.4> <v0.6.4> Bump version                                                                        
2019-10-23 13:47 -0400 Fabian von Feilitzsch      o py3 test fix (#330)
2019-10-22 16:22 -0400 Fabian von Feilitzsch      o Pin more requirements
2019-10-22 15:21 -0400 Fabian von Feilitzsch      o Reduce build matrix
2019-10-22 14:18 -0500 OpenShift Cherrypick Robot o Do not decode response data in Python2 (#329)
2019-10-22 15:12 -0400 Fabian von Feilitzsch      o Update tests and pin dependencies to prevent irrelevant failures
2018-08-17 12:58 -0400 Fabian von Feilitzsch      o <v0.6.3> Fix version pin to kubernetes 6.0.0, bump version
2018-07-13 14:46 -0400 Fabian von Feilitzsch      o [release-0.6.2] {upstream/release-0.6.2} <v0.6.2> include version update script
2018-07-13 14:45 -0400 Fabian von Feilitzsch      o Version bump to 0.6.2
```

So the only commits that I saw that were in `release-0.7` when `0.6.2-12` was tagged and built are the following commits:
```
2018-08-02 09:08 -0500 Andrew DeMaria             o Fix decode issue (#192)
2018-07-30 10:39 +0200 Fridolin Pokorny           o b64encode expects bytes not string
2018-07-23 15:51 -0400 David Zager                │ o Update releasers for 3.11
```

The `Automatic commit of package...` commits have `.spec` file `%changelog` changes that I will pick up when I do a `tito tag` and release of the `release-0.6` branch.