### PR TITLE
Add strategic merge key for admission webhooks

### DIFF
--- a/openshift/dynamic/apply.py
+++ b/openshift/dynamic/apply.py
@@ -41,6 +41,8 @@ POD_SPEC_PREFIXES = [
 STRATEGIC_MERGE_PATCH_KEYS = {
     'Service.spec.ports': 'port',
     'ServiceAccount.secrets': 'name',
+    'ValidatingWebhookConfiguration.webhooks': 'name',
+    'MutatingWebhookConfiguration.webhooks': 'name',
 }
 
 STRATEGIC_MERGE_PATCH_KEYS.update(


### PR DESCRIPTION
This is the last barrier to a change-less cert-manager deployment