### PR TITLE
Fix exception with empty resource list

### DIFF
--- a/openshift/dynamic/resource.py
+++ b/openshift/dynamic/resource.py
@@ -276,7 +276,7 @@ class ResourceInstance(object):
         kind = instance['kind']
         if kind.endswith('List') and 'items' in instance:
             kind = instance['kind'][:-4]
-            if instance['items]:
+            if instance['items']:
                 for item in instance['items']:
                     if 'apiVersion' not in item:
                         item['apiVersion'] = instance['apiVersion']

--- a/openshift/dynamic/resource.py
+++ b/openshift/dynamic/resource.py
@@ -276,11 +276,12 @@ class ResourceInstance(object):
         kind = instance['kind']
         if kind.endswith('List') and 'items' in instance:
             kind = instance['kind'][:-4]
-            for item in instance['items']:
-                if 'apiVersion' not in item:
-                    item['apiVersion'] = instance['apiVersion']
-                if 'kind' not in item:
-                    item['kind'] = kind
+            if instance['items]:
+                for item in instance['items']:
+                    if 'apiVersion' not in item:
+                        item['apiVersion'] = instance['apiVersion']
+                    if 'kind' not in item:
+                        item['kind'] = kind
 
         self.attributes = self.__deserialize(instance)
         self.__initialised = True


### PR DESCRIPTION
Fix exception that occurs when query returns empty resource list.
Iterate over the list items only if it is not None.