### PR TITLE
Add iterator to ResourceGroup to support EagerDiscoverer iteration

### DIFF
--- a/openshift/dynamic/discovery.py
+++ b/openshift/dynamic/discovery.py
@@ -414,7 +414,7 @@ class EagerDiscoverer(Discoverer):
         for _, groups in self.__resources.items():
             for _, versions in groups.items():
                 for _, resources in versions.items():
-                    for _, resource in resources.items():
+                    for resource in resources:
                         yield resource
 
 
@@ -430,6 +430,12 @@ class ResourceGroup(object):
             'preferred': self.preferred,
             'resources': self.resources,
         }
+
+    def __iter__(self):
+        for _, resource_list in self.resources.items():
+            for r in resource_list:
+                yield r
+
 
 
 class CacheEncoder(json.JSONEncoder):


### PR DESCRIPTION
New to the module, I attempted a discovery of all resources...

```from kubernetes import client, config
from openshift.dynamic import DynamicClient
from openshift.dynamic import EagerDiscoverer

k8s_client = config.new_client_from_config()
dyn_client = DynamicClient(k8s_client, discoverer=EagerDiscoverer)

for g in dyn_client.resources.api_groups:
    print("api_group: %s" % g)

for r in dyn_client.resources:
    print("resource: %s" % r)
```


This fails with:

```
...
api_group: metrics.k8s.io
Traceback (most recent call last):
  File "./list_resources.py", line 13, in <module>
    for r in dyn_client.resources:
  File "/home/bowe/b/openshift-restclient-python/openshift/dynamic/discovery.py", line 417, in __iter__
    for _, resource in resources.items():
AttributeError: 'ResourceGroup' object has no attribute 'items'
```

This PR successfully supports interation, with what seems to be the expected items:

```
...
api_group: machine.openshift.io                                                 
api_group: metrics.k8s.io                                                       
resource: <Resource(v1/bindings)>                                               
resource: <ResourceList(v1/bindings)>                                           
resource: <Resource(v1/componentstatuses)>                                      
resource: <ResourceList(v1/componentstatuses)>                                  
resource: <Resource(v1/configmaps)>                                             
resource: <ResourceList(v1/configmaps)>
...
```                                        

