### PR TITLE
Fix UnboundLocalError generating a diff

### DIFF
--- a/openshift/dynamic/apply.py
+++ b/openshift/dynamic/apply.py
@@ -223,8 +223,7 @@ def recursive_diff(dict1, dict2, position=None):
     left = dict((k, v) for (k, v) in dict1.items() if k not in dict2)
     right = dict((k, v) for (k, v) in dict2.items() if k not in dict1)
     for k in (set(dict1.keys()) & set(dict2.keys())):
-        if position:
-            this_position = "%s.%s" % (position, k)
+        this_position = "%s.%s" % (position, k) if position is not None else None
         if isinstance(dict1[k], dict) and isinstance(dict2[k], dict):
             result = recursive_diff(dict1[k], dict2[k], this_position)
             if result:

--- a/test/unit/test_diff.py
+++ b/test/unit/test_diff.py
@@ -61,6 +61,51 @@ tests = [
         expected=(dict(spec=dict(containers=[dict(name="busybox", env=[dict(name="another", value="next"), dict(name="hello", value="world")])])),
                   dict(spec=dict(containers=[dict(name="busybox", env=[dict(name="hello", value="everyone")])])))
     ),
+
+    dict(
+        before = dict(
+            kind="Pod",
+            metadata=dict(name="foo"),
+            spec=dict(containers=[dict(name="busybox", image="busybox")])
+        ),
+        after = dict(
+            kind="Service",
+            metadata=dict(name="foo"),
+            spec=dict(ports=[dict(port=8081, name="http")])
+        ),
+        expected=(dict(kind='Pod', spec=dict(containers=[dict(image='busybox', name='busybox')])),
+                  dict(kind='Service', spec=dict(ports=[dict(name='http', port=8081)])))
+    ),
+
+    dict(
+        before = dict(
+            kind="Pod",
+            metadata=dict(name="foo"),
+            spec=dict(containers=[dict(name="busybox", image="busybox")])
+        ),
+        after = dict(
+            # kind="...",
+            metadata=dict(name="foo"),
+            spec=dict(ports=[dict(port=8081, name="http")])
+        ),
+        expected=(dict(kind='Pod', spec=dict(containers=[dict(image='busybox', name='busybox')])),
+                  dict(spec=dict(ports=[dict(name='http', port=8081)])))
+    ),
+
+    dict(
+        before = dict(
+            # kind="...",
+            metadata=dict(name="foo"),
+            spec=dict(containers=[dict(name="busybox", image="busybox")])
+        ),
+        after = dict(
+            kind="Service",
+            metadata=dict(name="foo"),
+            spec=dict(ports=[dict(port=8081, name="http")])
+        ),
+        expected=(dict(spec=dict(containers=[dict(image='busybox', name='busybox')])),
+                  dict(kind='Service', spec=dict(ports=[dict(name='http', port=8081)])))
+    ),
     ]
 
 


### PR DESCRIPTION
This happens two resources of different kind are compared or
of 'kind' is missing in the dict.

```
Traceback (most recent call last):
   File "/tmp/ansible_k8s_payload_trnxlugx/ansible_k8s_payload.zip/ansible_collections/community/kubernetes/plugins/modules/k8s.py", line 320, in <module>
   File "/tmp/ansible_k8s_payload_trnxlugx/ansible_k8s_payload.zip/ansible_collections/community/kubernetes/plugins/modules/k8s.py", line 316, in main
   File "/tmp/ansible_k8s_payload_trnxlugx/ansible_k8s_payload.zip/ansible_collections/community/kubernetes/plugins/module_utils/common.py", line 548, in execute_module
   File "/tmp/ansible_k8s_payload_trnxlugx/ansible_k8s_payload.zip/ansible_collections/community/kubernetes/plugins/module_utils/common.py", line 760, in perform_action
   File "/tmp/ansible_k8s_payload_trnxlugx/ansible_k8s_payload.zip/ansible_collections/community/kubernetes/plugins/module_utils/common.py", line 347, in diff_objects
   File "/home/linosteiner/.local/lib/python3.9/site-packages/openshift/dynamic/apply.py", line 232, in recursive_diff
      result = recursive_list_diff(dict1[k], dict2[k], this_position)
UnboundLocalError: local variable 'this_position' referenced before assignment
```