### PR TITLE
Add an option to provide "Accept" header to client request

### DIFF
--- a/openshift/dynamic/client.py
+++ b/openshift/dynamic/client.py
@@ -186,7 +186,7 @@ class DynamicClient(object):
             yield event
 
     @meta_request
-    def request(self, method, path, body=None, **params):
+    def request(self, method, path, body=None, accept_header=None, **params):
         if not path.startswith('/'):
             path = '/' + path
 
@@ -217,7 +217,7 @@ class DynamicClient(object):
         form_params = []
         local_var_files = {}
         # HTTP header `Accept`
-        header_params['Accept'] = self.client.select_header_accept([
+        header_params['Accept'] = accept_header or self.client.select_header_accept([
             'application/json',
             'application/yaml',
             'application/vnd.kubernetes.protobuf'


### PR DESCRIPTION
The `client.request` function always use the same accept header (`application/json`) which in some cases can be wrong
Therefore, add an option to the caller to add the required header
Default behavior (caller doesn't provide the header) stays the same