### PR TITLE
Upgrade `kubernetes >= 12.0`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,14 @@
 sudo: required
 services:
-- docker
+  - docker
 cache:
-- pip
+  - pip
 language: python
 python:
-- '2.7'
-- '3.8'
+  - '3.9'
+  - '3.8'
+  - '3.7'
+  - '3.6'
 env:
   global:
     - COVERALLS_PARALLEL=true
@@ -19,27 +21,21 @@ env:
     - TEST_SUITE=dynamic-functional OPENSHIFT_VERSION=latest
 script: tox
 install:
-- pip install tox-travis coveralls
+  - pip install tox-travis coveralls
 after_success:
-- coveralls
+  - coveralls
 jobs:
   include:
   - stage: lint
-    python: '2.7'
+    python: '3.9'
     install:
-    - pip install tox-travis
-    script: tox -e py27-lint
-    env:
-    - TEST_SUITE=lint OPENSHIFT_VERSION=latest
-  - python: '3.8'
-    install:
-    - pip install tox-travis
+      - pip install tox-travis
     script: tox -e py35-lint
     env:
-    - TEST_SUITE=lint OPENSHIFT_VERSION=latest
+      - TEST_SUITE=lint OPENSHIFT_VERSION=latest
   - stage: deploy
     script: skip
-    python: '3.8'
+    python: '3.9'
     deploy:
       provider: pypi
       user: openshift
@@ -50,16 +46,16 @@ jobs:
         repo: openshift/openshift-restclient-python
         condition: "$TRAVIS_TAG =~ ^v[0-9]+\\.[0-9]+\\.[0-9]+(([ab]|dev|rc)[0-9]+)?$"
   - stage: test-deploy
-    python: '3.8'
+    python: '3.9'
     script: python -c "import openshift ; print(openshift.__version__)"
     install:
       - pip install openshift
 stages:
-- lint
-- test
-- name: deploy
-  if: (tag is present) and (type = push)
-- name: test-deploy
-  if: (tag is present) and (type = push)
+  - lint
+  - test
+  - name: deploy
+    if: (tag is present) and (type = push)
+  - name: test-deploy
+    if: (tag is present) and (type = push)
 notifications:
   webhooks: https://coveralls.io/webhook

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 jinja2
-kubernetes ~= 12.0
+kubernetes >= 12.0
 python-string-utils
 ruamel.yaml
 six

--- a/setup.py
+++ b/setup.py
@@ -61,10 +61,11 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
     entry_points={
         'console_scripts': ['openshift-ansible-gen = openshift.ansiblegen.cli:commandline']


### PR DESCRIPTION
With master branch we simply pin dependency with `kubernetes`, but now
branch `release-0.12` having a hard limit with `kubernetes ~= 12.0`.

BTW, https://github.com/kubernetes-client/python/releases/tag/v12.0.1
was released on 2020-11-10, where today least release is
https://github.com/kubernetes-client/python/releases/tag/v19.15.0.

This PR remove the upper limit with `kubernetes >= 12.0`.

Signed-off-by: Wong Hoi Sing Edison <hswong3i@pantarei-design.com>