### PR TITLE
[git cherry-pick 8cd3fd9] Upgrade `kubernetes >= 12.0`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,14 @@
 sudo: required
 services:
-- docker
+  - docker
 cache:
-- pip
+  - pip
 language: python
 python:
-- '3.9'
+  - '3.6'
+  - '3.7'
+  - '3.8'
+  - '3.9'
 env:
   global:
     - COVERALLS_PARALLEL=true
@@ -13,19 +16,13 @@ env:
     - TEST_SUITE=unit
 script: tox
 install:
-- pip install tox-travis coveralls
+  - pip install tox-travis coveralls
 after_success:
-- coveralls
+  - coveralls
 jobs:
   include:
   - stage: lint
     python: '3.9'
-    install:
-    - pip install tox-travis
-    script: tox -e py27-lint
-    env:
-    - TEST_SUITE=lint
-  - python: '3.9'
     install:
     - pip install tox-travis
     script: tox -e py35-lint
@@ -49,11 +46,11 @@ jobs:
     install:
       - pip install openshift
 stages:
-# - lint
-# - test
-- name: deploy
-  if: (tag is present) and (type = push)
-- name: test-deploy
-  if: (tag is present) and (type = push)
+  - lint
+  - test
+  - name: deploy
+    if: (tag is present) and (type = push)
+  - name: test-deploy
+    if: (tag is present) and (type = push)
 notifications:
   webhooks: https://coveralls.io/webhook

--- a/setup.py
+++ b/setup.py
@@ -57,9 +57,10 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
 )


### PR DESCRIPTION
With master branch we simply pin dependency with `kubernetes`, but now
branch `release-0.12` having a hard limit with `kubernetes ~= 12.0`.

BTW, https://github.com/kubernetes-client/python/releases/tag/v12.0.1
was released on 2020-11-10, where today least release is
https://github.com/kubernetes-client/python/releases/tag/v19.15.0.

This PR remove the upper limit with `kubernetes >= 12.0`.

Signed-off-by: Wong Hoi Sing Edison <hswong3i@pantarei-design.com>