### PR TITLE
Force update to ver 3.2.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ python-string-utils
 ruamel.yaml
 six
 requests
-requests-oauthlib
+requests-oauthlib>=3.2.2


### PR DESCRIPTION
This PR is to try fixing the requests-oauthlib:3.2.1 vulnerability described here: https://github.com/openshift/openshift-restclient-python/issues/433